### PR TITLE
feat: implement janitor to clean the cache of expired items

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ import (
 )
 
 func main() {
-	// Create a cache with a default expiration time of 5 minutes.
-	c := cache.New(cache.Expiration(5 * time.Minute))
+	// Create a cache with a default expiration time of 5 minutes and a
+	// cleanup interval of 10 minutes.
+	c := cache.New(
+		cache.Expiration(5 * time.Minute),
+		cache.CleanupInterval(10 * time.Minute),
+	)
 
 	// Set the value of the key "foo" to "bar" with the default expiration
 	// time.
@@ -51,7 +55,7 @@ func main() {
 
 ## Reference
 
-Documentation can be found using the `go doc` command or at [pkg.go.dev][docs]
+Documentation can be found using the `go doc` command or at [pkg.go.dev][docs].
 
 ## Credits
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -105,3 +105,12 @@ func TestDefaultExpiration(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, v)
 }
+
+func TestCleanupInterval(t *testing.T) {
+	c := New(CleanupInterval(time.Millisecond))
+	c.Put("foo", "bar", 3*time.Millisecond)
+
+	<-time.After(5 * time.Millisecond)
+
+	assert.NotContains(t, c.WithExpired(true).Items(), "foo")
+}

--- a/janitor.go
+++ b/janitor.go
@@ -1,0 +1,48 @@
+package cache
+
+import (
+	"time"
+)
+
+// Janitor is the interface that is responsible for cleaning the cache of
+// expired items.
+type Janitor interface {
+	// Start runs the main janitor loop responsible for cleaning the cache of
+	// expired items. It accepts the cache to watch as its first argument and
+	// returns nothing.
+	Start(c Cache)
+	// Stop stops the janitor from cleaning the cache of expired items. It
+	// accepts the cache to stop watching as its first argument and returns
+	// nothing.
+	Stop(c Cache)
+}
+
+// NewJanitor returns a new janitor.
+func NewJanitor(ci time.Duration) Janitor {
+	return &janitor{
+		interval: ci,
+		stop:     make(chan bool),
+	}
+}
+
+type janitor struct {
+	interval time.Duration
+	stop     chan bool
+}
+
+func (j *janitor) Start(c Cache) {
+	ticker := time.NewTicker(j.interval)
+	for {
+		select {
+		case <-ticker.C:
+			c.DeleteExpired()
+		case <-j.stop:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func (j *janitor) Stop(c Cache) {
+	close(j.stop)
+}

--- a/janitor_test.go
+++ b/janitor_test.go
@@ -1,0 +1,35 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJanitorStart(t *testing.T) {
+	j := &janitor{
+		interval: time.Millisecond,
+		stop:     make(chan bool),
+	}
+	c := New()
+	c.Put("foo", "bar", 3*time.Millisecond)
+
+	go j.Start(c)
+	<-time.After(5 * time.Millisecond)
+
+	assert.NotContains(t, c.WithExpired(true).Items(), "foo")
+}
+
+func TestJanitorStop(t *testing.T) {
+	j := &janitor{
+		interval: time.Millisecond,
+		stop:     make(chan bool),
+	}
+	c := New()
+	go j.Start(c)
+
+	j.Stop(c)
+
+	assert.False(t, <-j.stop)
+}

--- a/options.go
+++ b/options.go
@@ -9,6 +9,9 @@ type Options struct {
 	Items map[string]Item
 	// Expiration represents the default expiration of the cache.
 	Expiration time.Duration
+	// CleanupInterval represents the default interval for the janitor to clean
+	// the cache of expired items.
+	CleanupInterval time.Duration
 }
 
 // Option manipulates the Options passed.
@@ -28,11 +31,20 @@ func Expiration(e time.Duration) Option {
 	}
 }
 
+// CleanupInterval sets the interval for the janitor to clean the cache of
+// expired items.
+func CleanupInterval(ci time.Duration) Option {
+	return func(o *Options) {
+		o.CleanupInterval = ci
+	}
+}
+
 // NewOptions returns a new Options struct.
 func NewOptions(opts ...Option) Options {
 	options := Options{
-		Items:      make(map[string]Item),
-		Expiration: DefaultExpiration,
+		Items:           make(map[string]Item),
+		Expiration:      DefaultExpiration,
+		CleanupInterval: DefaultCleanupInterval,
 	}
 	for _, o := range opts {
 		o(&options)


### PR DESCRIPTION
In v1.0.0 expired items are not removed from the cache automatically contrary to possible expectations. Expired items will remain in the cache indefinitely until the item is specifically requested to be removed. The lack of automatically cleaning up expired items from the cache may lead to confusion and frustration when users are observing the consumed memory rise while items in the cache are expiring.

To help resolve this I'm introducing the janitor. By default the janitor is off. Developers may turn it on by configuring a `CleanupInterval` on the cache, as per the example below. Additionally developers can now fetch items with expired items by using the `WithExpired` fluent method.

```go
package main

import (
	"fmt"
	"time"

	"github.com/guardian360/go-cache"
)

func main() {
	c := cache.New(
		cache.CleanupInterval(5 * time.Millisecond),
	)
	c.Put("foo", "bar", time.Millisecond)

	// Key "foo" is present in the cache
	fmt.Println(c.WithExpired(true).Items())

	<-time.After(10 * time.Millisecond)

	// Key "foo" is no longer present in the cache
	fmt.Println(c.WithExpired(true).Items())
}
```